### PR TITLE
Add sinkResponseHandler to allow user register a callback after response

### DIFF
--- a/couchbase/processor.go
+++ b/couchbase/processor.go
@@ -32,6 +32,7 @@ type Processor struct {
 	batchSizeLimit      int
 	flushLock           sync.Mutex
 	isDcpRebalancing    bool
+	sinkResponseHandler SinkResponseHandler
 }
 
 type Metric struct {
@@ -43,6 +44,7 @@ func NewProcessor(
 	config *config.Config,
 	client Client,
 	dcpCheckpointCommit func(),
+	sinkResponseHandler SinkResponseHandler,
 ) (*Processor, error) {
 	processor := &Processor{
 		client:              client,
@@ -55,6 +57,7 @@ func NewProcessor(
 		collectionName:      config.Couchbase.CollectionName,
 		dcpCheckpointCommit: dcpCheckpointCommit,
 		metric:              &Metric{},
+		sinkResponseHandler: sinkResponseHandler,
 	}
 
 	return processor, nil
@@ -127,19 +130,44 @@ func (b *Processor) GetMetric() *Metric {
 	return b.metric
 }
 
-func panicOrGo(err error, wg *sync.WaitGroup) {
+func (b *Processor) panicOrGo(action CBActionDocument, err error, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	isRequestSuccessful := false
 	if err == nil {
-		wg.Done()
-		return
+		isRequestSuccessful = true
 	}
 
 	var kvErr *gocbcore.KeyValueError
 	if errors.As(err, &kvErr) && kvErr.StatusCode == memd.StatusKeyNotFound {
-		wg.Done()
+		isRequestSuccessful = true
+	}
+
+	if isRequestSuccessful {
+		b.handleSuccess(&action)
 		return
 	}
 
-	panic(err)
+	b.handleError(&action, err)
+}
+
+func (b *Processor) handleError(action *CBActionDocument, err error) {
+	if b.sinkResponseHandler == nil {
+		panic(err)
+	}
+
+	b.sinkResponseHandler.OnError(&SinkResponseHandlerContext{
+		Action: action,
+		Err:    err,
+	})
+}
+
+func (b *Processor) handleSuccess(action *CBActionDocument) {
+	if b.sinkResponseHandler != nil {
+		b.sinkResponseHandler.OnSuccess(&SinkResponseHandlerContext{
+			Action: action,
+		})
+	}
 }
 
 func (b *Processor) bulkRequest() {
@@ -158,22 +186,22 @@ func (b *Processor) bulkRequest() {
 		case v.Type == Set:
 			err = b.client.CreateDocument(ctx, b.scopeName, b.collectionName, v.ID, v.Source, 0, 0,
 				func(result *gocbcore.StoreResult, err error) {
-					panicOrGo(err, &wg)
+					b.panicOrGo(v, err, &wg)
 				})
 		case v.Type == MutateIn:
 			err = b.client.CreatePath(ctx, b.scopeName, b.collectionName, v.ID, v.Path, v.Source, memd.SubdocDocFlagMkDoc,
 				func(result *gocbcore.MutateInResult, err error) {
-					panicOrGo(err, &wg)
+					b.panicOrGo(v, err, &wg)
 				})
 		case v.Type == DeletePath:
 			err = b.client.DeletePath(ctx, b.scopeName, b.collectionName, v.ID, v.Path,
 				func(result *gocbcore.MutateInResult, err error) {
-					panicOrGo(err, &wg)
+					b.panicOrGo(v, err, &wg)
 				})
 		case v.Type == Delete:
 			err = b.client.DeleteDocument(ctx, b.scopeName, b.collectionName, v.ID,
 				func(result *gocbcore.DeleteResult, err error) {
-					panicOrGo(err, &wg)
+					b.panicOrGo(v, err, &wg)
 				})
 		default:
 			logger.Log.Error("Unexpected action type: %v", v.Type)

--- a/couchbase/sink_response_handler.go
+++ b/couchbase/sink_response_handler.go
@@ -1,0 +1,11 @@
+package couchbase
+
+type SinkResponseHandlerContext struct {
+	Action *CBActionDocument
+	Err    error
+}
+
+type SinkResponseHandler interface {
+	OnSuccess(ctx *SinkResponseHandlerContext)
+	OnError(ctx *SinkResponseHandlerContext)
+}

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"fmt"
 	"github.com/Trendyol/go-dcp-couchbase"
+	"github.com/Trendyol/go-dcp-couchbase/couchbase"
 )
 
 func main() {
+
 	connector, err := dcpcouchbase.NewConnectorBuilder("config.yml").
 		SetMapper(dcpcouchbase.DefaultMapper).
+		SetSinkResponseHandler(&sinkResponseHandler{}).
 		Build()
 	if err != nil {
 		panic(err)
@@ -15,4 +19,15 @@ func main() {
 	defer connector.Close()
 	connector.Start()
 
+}
+
+type sinkResponseHandler struct {
+}
+
+func (s *sinkResponseHandler) OnSuccess(ctx *couchbase.SinkResponseHandlerContext) {
+	fmt.Printf("OnSuccess %v\n", string(ctx.Action.Source))
+}
+
+func (s *sinkResponseHandler) OnError(ctx *couchbase.SinkResponseHandlerContext) {
+	fmt.Printf("OnError %v\n", string(ctx.Action.Source))
 }


### PR DESCRIPTION
This commit will allow users to register any callback method after the sink response. After the change users will be able to decide what the client should do in case of a write error.

Resolves #11 