### PR TITLE
feat: allow explicit control over flags for Set operations

### DIFF
--- a/couchbase/client.go
+++ b/couchbase/client.go
@@ -360,40 +360,40 @@ func (s *client) Execute(ctx context.Context, action *CBActionDocument, callback
 	switch action.Type {
 	case Set:
 		err = s.CreateDocument(ctx, s.config.ScopeName, s.config.CollectionName,
-			action.ID, action.Source, 0, action.Expiry,
+			action.ID, action.Source, action.DocumentFlags, action.Expiry,
 			func(result *gocbcore.StoreResult, err error) {
 				callback(err)
 			})
 	case MutateIn:
-		flags := memd.SubdocDocFlagMkDoc
+		subDocFlags := memd.SubdocDocFlagMkDoc
 		if action.DisableAutoCreate {
-			flags = memd.SubdocDocFlagNone
+			subDocFlags = memd.SubdocDocFlagNone
 		}
 
 		err = s.CreatePath(ctx, s.config.ScopeName, s.config.CollectionName,
-			action.ID, action.Path, action.Source, flags, casPtr, action.Expiry, action.PreserveExpiry,
+			action.ID, action.Path, action.Source, subDocFlags, casPtr, action.Expiry, action.PreserveExpiry,
 			func(result *gocbcore.MutateInResult, err error) {
 				callback(err)
 			})
 	case MultiMutateIn:
-		flags := memd.SubdocDocFlagMkDoc
+		subDocFlags := memd.SubdocDocFlagMkDoc
 		if action.DisableAutoCreate {
-			flags = memd.SubdocDocFlagNone
+			subDocFlags = memd.SubdocDocFlagNone
 		}
 
 		err = s.CreateMultiPath(ctx, s.config.ScopeName, s.config.CollectionName,
-			action.ID, action.PathValues, flags, casPtr, action.Expiry, action.PreserveExpiry,
+			action.ID, action.PathValues, subDocFlags, casPtr, action.Expiry, action.PreserveExpiry,
 			func(result *gocbcore.MutateInResult, err error) {
 				callback(err)
 			})
 	case ArrayAppend:
-		flags := memd.SubdocDocFlagMkDoc
+		subDocFlags := memd.SubdocDocFlagMkDoc
 		if action.DisableAutoCreate {
-			flags = memd.SubdocDocFlagNone
+			subDocFlags = memd.SubdocDocFlagNone
 		}
 
 		err = s.ArrayAppend(ctx, s.config.ScopeName, s.config.CollectionName,
-			action.ID, action.Path, action.Source, flags, casPtr, action.Expiry, action.PreserveExpiry,
+			action.ID, action.Path, action.Source, subDocFlags, casPtr, action.Expiry, action.PreserveExpiry,
 			func(result *gocbcore.MutateInResult, err error) {
 				callback(err)
 			})

--- a/couchbase/document.go
+++ b/couchbase/document.go
@@ -17,9 +17,16 @@ const (
 	Increment     CbAction = "Increment"
 )
 
+type DocumentType uint8
+
 type CBActionDocument struct {
-	Cas               *uint64
-	Type              CbAction
+	Cas  *uint64
+	Type CbAction
+	// DocumentFlags specifies the common flags for a full-document operation (like Set).
+	// It is used to control data format (JSON, binary, string) and compression.
+	// The value should be generated using gocbcore.EncodeCommonFlags.
+	// If left as 0 (default), the SDK will attempt to infer the data type.
+	DocumentFlags     uint32
 	PathValues        []PathValue
 	Source            []byte
 	ID                []byte
@@ -42,6 +49,13 @@ func (doc *CBActionDocument) SetExpiry(expiry uint32) {
 
 func (doc *CBActionDocument) SetPreserveExpiry(preserveExpiry bool) {
 	doc.PreserveExpiry = preserveExpiry
+}
+
+// SetDocumentFlags sets the common flags for a full-document operation.
+// This allows for explicit control over the document's data format.
+func (doc *CBActionDocument) SetDocumentFlags(flags uint32) *CBActionDocument {
+	doc.DocumentFlags = flags
+	return doc
 }
 
 func (doc *CBActionDocument) SetDisableAutoCreate(value bool) {

--- a/example/custom-flags/Dockerfile
+++ b/example/custom-flags/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.24-alpine as builder
+
+WORKDIR /project
+
+COPY go.mod go.sum ./
+COPY main.go ./
+COPY config.yml ./config.yml
+
+RUN go mod download
+RUN CGO_ENABLED=0 go build -a -o example main.go
+
+FROM alpine:3.17.0
+
+WORKDIR /app
+
+RUN apk --no-cache add ca-certificates
+
+USER nobody
+COPY --from=builder --chown=nobody:nobody /project/example .
+COPY --from=builder --chown=nobody:nobody /project/config.yml ./config.yml
+
+ENTRYPOINT ["./example"]

--- a/example/custom-flags/config.yml
+++ b/example/custom-flags/config.yml
@@ -1,0 +1,20 @@
+hosts:
+  - localhost:8091
+username: user
+password: password
+bucketName: dcp-test
+dcp:
+  group:
+    name: groupName
+metadata:
+  type: couchbase
+  config:
+    bucket: dcp-test-meta
+    scope: _default
+    collection: _default
+couchbase:
+  hosts:
+    - localhost:8091
+  username: user
+  password: password
+  bucketName: dcp-test-backup

--- a/example/custom-flags/go.mod
+++ b/example/custom-flags/go.mod
@@ -1,0 +1,10 @@
+module github.com/Trendyol/go-dcp-couchbase/example/custom-flags
+
+go 1.24.0
+
+replace github.com/Trendyol/go-dcp-couchbase => ../../
+
+require (
+	github.com/Trendyol/go-dcp-couchbase v0.0.0-00010101000000-000000000000
+	github.com/couchbase/gocbcore/v10 v10.7.1
+)

--- a/example/custom-flags/go.sum
+++ b/example/custom-flags/go.sum
@@ -1,0 +1,6 @@
+github.com/couchbase/gocbcore/v10 v10.7.1/go.mod h1:Q8JWVenMCEOuRgrDQKApHbzzPif38HzefGgRVe9apAI=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/example/custom-flags/main.go
+++ b/example/custom-flags/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/couchbase/gocbcore/v10"
+
+	dcpcouchbase "github.com/Trendyol/go-dcp-couchbase"
+	"github.com/Trendyol/go-dcp-couchbase/couchbase"
+)
+
+func mapper(ctx couchbase.EventContext) []couchbase.CBActionDocument {
+	// We are only interested in mutation events
+	if !ctx.Event.IsMutated {
+		return nil
+	}
+
+	// Create the flag for the JSON format.
+	// gocbcore.JSONType is equal to gocbcore.DataType(1).
+	jsonFlags := gocbcore.EncodeCommonFlags(gocbcore.JSONType, gocbcore.NoCompression)
+
+	// Action to save the original document as JSON
+	action := couchbase.NewSetAction(ctx.Event.Key, ctx.Event.Value)
+	setAction := action.SetDocumentFlags(jsonFlags)
+
+	// Create the flag for the Binary format.
+	// gocbcore.BinaryType is equal to gocbcore.DataType(2).
+	binaryFlags := gocbcore.EncodeCommonFlags(gocbcore.BinaryType, gocbcore.NoCompression)
+
+	// Action to save the raw content (value) of the document as binary with a different key
+	backupKey := append([]byte("backup:"), ctx.Event.Key...)
+	backupSetAction := couchbase.NewSetAction(backupKey, ctx.Event.Value)
+	backupAction := backupSetAction.SetDocumentFlags(binaryFlags)
+
+	// Send both created actions to the processor
+	return []couchbase.CBActionDocument{*setAction, *backupAction}
+}
+
+func main() {
+	c, err := dcpcouchbase.NewConnectorBuilder("config.yml").
+		SetMapper(mapper).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+
+	c.Start()
+	defer c.Close()
+
+	fmt.Println("Connector started")
+
+	// Graceful shutdown
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+	<-signalChan
+}


### PR DESCRIPTION
### **Title: Allow explicit control over flags for Set operations**

#### What does this PR do?

This pull request enhances the framework's flexibility by allowing developers to explicitly set the 32-bit "Common Flags" for `Set` (full-document) operations. This gives developers direct control over how a document's data format (e.g., JSON, Binary) is stored in Couchbase.

The main changes include:
1.  A new `DocumentFlags` field (`uint32`) has been added to the `CBActionDocument` struct. This name was chosen to be explicit that these flags apply to full-document operations only.
2.  A new fluent method, `SetDocumentFlags(flags uint32)`, has been added to `CBActionDocument` to easily set this value.
3.  The `Execute` method in `couchbase/client.go` has been updated to use this `DocumentFlags` value when performing a `Set` operation.
4.  A new example, `example/custom-flags`, has been added to demonstrate how to use this new feature.
5.  As a code quality improvement, internal variables for sub-document flags in the `Execute` method have been renamed from `flags` to `subDocFlags` to improve clarity and prevent confusion with `DocumentFlags`.

This change does **not** affect sub-document operations like `MutateIn`, which continue to use their existing logic.

#### Why is this change necessary?

Previously, when performing a `Set` operation, the `flags` parameter was hardcoded to `0`, forcing the Couchbase SDK to infer the data format of the document content. While this works for many cases, it prevents developers from explicitly storing data as a specific type, such as `Binary`.

This change gives the developer full control over the data format, ensuring that documents are stored with the correct type information as intended.

#### How to use the new feature?

Developers can now use the `SetDocumentFlags` method in their `mapper` function to specify the document's format. The recommended way to generate the flags is by using the `gocbcore.EncodeCommonFlags` utility function.

**Example Usage:**

```go
import "github.com/couchbase/gocbcore/v10"

func myMapper(ctx couchbase.EventContext) []couchbase.CBActionDocument {
    // We want to save this document's content explicitly as binary data.
    binaryFlags := gocbcore.EncodeCommonFlags(gocbcore.BinaryType, gocbcore.NoCompression)
    
    action := couchbase.NewSetAction(ctx.Event.Key, ctx.Event.Value)
    action = action.SetDocumentFlags(binaryFlags)

    return []couchbase.CBActionDocument{*action}
}
```

If the `SetDocumentFlags` method is not called, the `DocumentFlags` field will remain `0`, preserving the old behavior where the SDK infers the data type.